### PR TITLE
Add update/submit-claude skills and fix index-maintenance keyword spec

### DIFF
--- a/src/claude/skills/analysis/references/index-maintenance.md
+++ b/src/claude/skills/analysis/references/index-maintenance.md
@@ -220,25 +220,41 @@ When adding disproven companion file reference:
 
 ---
 
-## Keywords Section (MANDATORY)
+## Keyword Index Files (MANDATORY)
 
-List all unique keywords used across the topic and all subtopics, sorted alphabetically, with count of findings using each keyword.
+Keyword index files are separate files linked from the main index. Each file covers an alphabetical range of keywords. Small topics may use a single A-Z file; larger topics split across multiple files (A-D, E-L, M-P, Q-S, T-Z).
+
+**File naming:**
+```
+[topic]-index-keywords.md              (single file for small topics)
+[topic]-index-keywords-a-d.md         (split files for large topics)
+[topic]-index-keywords-e-l.md
+[topic]-index-keywords-m-p.md
+[topic]-index-keywords-q-s.md
+[topic]-index-keywords-t-z.md
+```
 
 **MUST:**
-- List keywords in alphabetical order
+- List keywords in alphabetical order within the file
 - Include count of findings using each keyword
 - Update counts when appending findings with keywords
 - Update counts when archiving disproven findings
 - Use bold formatting for keywords
+- Update the keyword count on each file's link in the main index when counts change
 
 **MUST NOT:**
-- Omit keywords section from index
+- List keywords inline in the main index file — use keyword index files only
 - List keywords without counts
 - Include keywords with zero findings
+- Create keyword index files for subtopics — all keywords go in the main topic's keyword files
 
-**Format:**
+**Format for keyword index files:**
 ```markdown
-## Keywords
+# [Topic] — Keywords [Range]
+
+**N keywords**
+
+---
 
 - **api** (12 findings)
 - **authentication** (8 findings)
@@ -377,15 +393,15 @@ Track generated analysis documents:
 
 ## Keywords
 
-- **accuracy** (5 findings)
-- **behavioral** (8 findings)
-- **context** (12 findings)
-- **hallucination** (15 findings)
-- **memory** (9 findings)
-- **pattern** (7 findings)
-- **performance** (6 findings)
-- **training** (11 findings)
-- **verification** (10 findings)
+Browse findings by keyword:
+
+- [Keywords A-D](ai-problems-analysis-index-keywords-a-d.md) - 14 keywords
+- [Keywords E-L](ai-problems-analysis-index-keywords-e-l.md) - 8 keywords
+- [Keywords M-P](ai-problems-analysis-index-keywords-m-p.md) - 6 keywords
+- [Keywords Q-S](ai-problems-analysis-index-keywords-q-s.md) - 4 keywords
+- [Keywords T-Z](ai-problems-analysis-index-keywords-t-z.md) - 5 keywords
+
+**Total:** 37 unique keywords across all findings
 
 ---
 

--- a/src/claude/skills/submit-claude/SKILL.md
+++ b/src/claude/skills/submit-claude/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: submit-claude
+description: Submit local .claude/ changes to the upstream repository as a pull request targeting the configured branch.
+disable-model-invocation: true
+context: fork
+
+allowed-tools:
+  - Read
+  - Glob
+  - AskUserQuestion
+  - Bash(mkdir -p .tmp)
+  - Bash(rm -rf .tmp/ai-devops-submit)
+  - Bash(rmdir --ignore-fail-on-non-empty .tmp)
+  - Bash(gh repo clone *)
+  - Bash(find .tmp/ai-devops-submit/src/claude *)
+  - Bash(find .claude *)
+  - Bash(rsync *)
+  - Bash(rm -f .tmp/ai-devops-submit/src/claude/*)
+  - Bash(git -C .tmp/ai-devops-submit *)
+  - Bash(gh pr create *)
+  - Bash(date *)
+---
+
+# Submit .claude to Upstream
+
+Submit changes from this project's `.claude/` folder to the upstream repository as a pull request.
+
+Files that exist in the upstream's `src/claude/` are updated automatically. Files that exist only locally (not present in the upstream) are confirmed with the user before inclusion.
+
+## Workflow
+
+### Step 1: Read configuration
+
+Read `${CLAUDE_SKILL_DIR}/../update-claude/config.md` and extract:
+
+- `repo` — the GitHub repository in `owner/repo` format
+- `branch` — the branch to target with the pull request
+
+Use these values wherever `$REPO` and `$BRANCH` appear in subsequent steps.
+
+### Step 2: Prepare workspace
+
+1. Create `.tmp/` if it does not exist:
+   ```
+   mkdir -p .tmp
+   ```
+2. Remove any previous submit clone:
+   ```
+   rm -rf .tmp/ai-devops-submit
+   ```
+
+### Step 3: Clone the upstream repository
+
+Clone the configured branch into `.tmp/ai-devops-submit`:
+
+```
+gh repo clone $REPO .tmp/ai-devops-submit -- --branch $BRANCH --single-branch
+```
+
+If the clone fails, stop and report the error. Do not proceed to subsequent steps.
+
+### Step 4: Categorise local files
+
+List all files currently in `.claude/` (recursively):
+
+```
+find .claude -type f
+```
+
+List all files in the clone's `src/claude/` (recursively):
+
+```
+find .tmp/ai-devops-submit/src/claude -type f
+```
+
+Strip path prefixes (`.claude/` and `src/claude/` respectively) to obtain relative paths for both sets, then classify:
+
+- **Upstream files** — relative path exists in **both** `.claude/` and the clone's `src/claude/`. These will be updated automatically.
+- **Local-only files** — relative path exists in `.claude/` but **not** in the clone's `src/claude/`. These require user confirmation.
+
+### Step 5: Query the user about local-only files
+
+If there are local-only files, present them to the user using `AskUserQuestion` with `multiSelect: true`. Ask which local-only files to include in the pull request. Note that files not selected will be excluded from the PR.
+
+If there are no local-only files, skip this step.
+
+### Step 6: Create a submit branch in the clone
+
+Get today's date:
+
+```
+date +%Y-%m-%d
+```
+
+Create a new branch — named `submit/YYYY-MM-DD` where `YYYY-MM-DD` is today's date — in the clone:
+
+```
+git -C .tmp/ai-devops-submit checkout -b submit/YYYY-MM-DD
+```
+
+### Step 7: Copy local changes into the clone
+
+rsync all `.claude/` files into `src/claude/` in the clone. This overwrites upstream files and adds all local-only files:
+
+```
+rsync -av .claude/ .tmp/ai-devops-submit/src/claude/
+```
+
+For each local-only file the user chose **not** to include, remove it from the clone:
+
+```
+rm -f .tmp/ai-devops-submit/src/claude/RELATIVE_PATH
+```
+
+### Step 8: Check for actual changes
+
+Run `git status` to check whether any files were modified:
+
+```
+git -C .tmp/ai-devops-submit status --short
+```
+
+If the working tree is clean (no modified, added, or deleted files), there is nothing to submit. Report this to the user, clean up, and stop.
+
+### Step 9: Commit and push
+
+Stage all changes:
+
+```
+git -C .tmp/ai-devops-submit add -A
+```
+
+Commit with a descriptive message:
+
+```
+git -C .tmp/ai-devops-submit commit -m "Update .claude from local workspace (YYYY-MM-DD)"
+```
+
+Push the submit branch to the upstream:
+
+```
+git -C .tmp/ai-devops-submit push origin submit/YYYY-MM-DD
+```
+
+### Step 10: Create the pull request
+
+Build a PR body listing what changed:
+- Updated files (upstream files that were overwritten)
+- Added files (local-only files approved by user at Step 5)
+
+Create the PR targeting `$BRANCH`:
+
+```
+gh pr create \
+  --repo $REPO \
+  --base $BRANCH \
+  --head submit/YYYY-MM-DD \
+  --title "Update .claude from local workspace (YYYY-MM-DD)" \
+  --body "BODY"
+```
+
+Display the PR URL to the user.
+
+### Step 11: Clean up
+
+Remove the temporary clone:
+
+```
+rm -rf .tmp/ai-devops-submit
+```
+
+Remove `.tmp/` if it is now empty:
+
+```
+rmdir --ignore-fail-on-non-empty .tmp
+```
+
+### Step 12: Report results
+
+Report:
+
+- Source repository and target branch
+- Files updated (upstream files overwritten)
+- Files added (local-only files the user approved)
+- Files excluded (local-only files the user chose not to include)
+- Pull request URL
+
+## MUST
+
+- Read config from `${CLAUDE_SKILL_DIR}/../update-claude/config.md`. Do not hardcode the repo or branch.
+- Query the user (Step 5) before including any local-only file — a file whose relative path does not exist in the clone's `src/claude/`.
+- Create a new submit branch and open a PR — never push directly to `$BRANCH`.
+- Check for actual changes (Step 8) before committing. Stop cleanly if there is nothing to submit.
+- Clean up `.tmp/ai-devops-submit` after every run, including after failures.
+- Include the resolved `repo` and `branch` values in the final report.
+
+## MUST NOT
+
+- Include local-only files in the PR without explicit user confirmation.
+- Push directly to `$BRANCH`.
+- Hardcode the repo or branch — always read them from config.
+- Leave `.tmp/ai-devops-submit` behind after the skill completes.
+- Proceed past Step 3 if the clone fails.

--- a/src/claude/skills/update-claude/SKILL.md
+++ b/src/claude/skills/update-claude/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: update-claude
+description: Update the .claude folder from a configured upstream repository and branch. Overwrites files that exist in the source; preserves locally-added files.
+disable-model-invocation: true
+context: fork
+
+allowed-tools:
+  - Read
+  - Bash(gh repo clone *)
+  - Bash(rsync *)
+  - Bash(rm -rf .tmp/ai-devops-update)
+  - Bash(rmdir --ignore-fail-on-non-empty .tmp)
+  - Bash(mkdir -p .tmp)
+  - Glob
+---
+
+# Update .claude from Source
+
+Update this project's `.claude/` folder from a configured upstream repository and branch.
+
+Files that exist in the source are overwritten with the latest version. Files present in `.claude/` that have no counterpart in the source are left intact.
+
+## Workflow
+
+### Step 1: Read configuration
+
+Read `${CLAUDE_SKILL_DIR}/config.md` and extract the values for:
+
+- `repo` — the GitHub repository in `owner/repo` format
+- `branch` — the branch to clone
+
+Use these values in all subsequent steps wherever `$REPO` and `$BRANCH` appear.
+
+### Step 2: Prepare workspace
+
+1. Create `.tmp/` if it does not exist:
+   ```
+   mkdir -p .tmp
+   ```
+2. Remove any previous update clone to ensure a clean state:
+   ```
+   rm -rf .tmp/ai-devops-update
+   ```
+
+### Step 3: Clone the source repository
+
+Clone the configured branch of the configured repository into `.tmp/ai-devops-update`:
+
+```
+gh repo clone $REPO .tmp/ai-devops-update -- --branch $BRANCH --single-branch
+```
+
+If the clone fails, stop and report the error. Do not proceed to subsequent steps.
+
+### Step 4: Copy updated files into .claude
+
+Run rsync to copy from the source into `.claude/`. Do not use `--delete`; omitting it preserves files in `.claude/` that have no counterpart in the source.
+
+```
+rsync -av .tmp/ai-devops-update/src/claude/ .claude/
+```
+
+Capture the rsync output — you will need it for the report in Step 6.
+
+### Step 5: Clean up
+
+Remove the temporary clone:
+
+```
+rm -rf .tmp/ai-devops-update
+```
+
+Remove `.tmp/` if it is now empty:
+
+```
+rmdir --ignore-fail-on-non-empty .tmp
+```
+
+### Step 6: Report results
+
+Report the following to the user:
+
+- Source used (`repo` and `branch` from config)
+- Files updated (already existed in `.claude/` and were overwritten)
+- Files added from source (did not previously exist in `.claude/`)
+- Count of files left intact (exist only in `.claude/`, not in the source)
+
+Derive the "left intact" count by comparing the rsync output against the full list of files currently in `.claude/` using Glob.
+
+## MUST
+
+- Read `${CLAUDE_SKILL_DIR}/config.md` before running any other step. Do not use hardcoded repo or branch values.
+- Omit `--delete` from the rsync command. Omitting it is what preserves locally-added files.
+- Stop and report immediately if the `gh repo clone` command fails.
+- Clean up `.tmp/ai-devops-update` after every run, including after failures.
+- Include the resolved `repo` and `branch` values in the report.
+
+## MUST NOT
+
+- Hardcode the repo or branch — always read them from `${CLAUDE_SKILL_DIR}/config.md`.
+- Add `--delete` or `--delete-after` to the rsync command.
+- Commit or push any changes — this skill updates files on disk only.
+- Leave `.tmp/ai-devops-update` behind after the skill completes.
+- Proceed past Step 3 if the clone fails.

--- a/src/claude/skills/update-claude/config.md
+++ b/src/claude/skills/update-claude/config.md
@@ -1,0 +1,4 @@
+# update-claude Configuration
+
+repo: minouris/ai-devops
+branch: ai-artifact/batch/authoring-workflow


### PR DESCRIPTION
## Summary

Three changes from the local workspace:

---

### Fix: `skills/analysis/references/index-maintenance.md` — resolve keyword index format contradiction

The spec had an internal contradiction between two sections:

- **Index Structure (MANDATORY)** template showed keywords as links to separate index files (`[Keywords A-D](topic-index-keywords-a-d.md)`)
- **Keywords Section (MANDATORY)** showed keywords listed inline in the main index file

The Index Structure template is the correct intent. This fix:

- Renames "Keywords Section (MANDATORY)" → **"Keyword Index Files (MANDATORY)"** to make its scope clear
- Adds `MUST NOT: List keywords inline in the main index file — use keyword index files only`
- Documents file naming conventions for split-range files (`a-d`, `e-l`, `m-p`, `q-s`, `t-z`) and single-file (`a-z`) topics
- Updates the Example Complete Index to show keyword file links instead of an inline keyword list
- Adds explicit guidance on when to split vs use a single file

---

### New: `skills/update-claude/` — pull upstream .claude into local workspace

A `disable-model-invocation` reference skill that updates the local `.claude/` folder from the configured upstream repository and branch. Uses `rsync` **without** `--delete` so locally-added files are preserved.

Includes `config.md` (shared with `submit-claude`):
```
repo: minouris/ai-devops
branch: ai-artifact/batch/authoring-workflow
```

---

### New: `skills/submit-claude/` — push local .claude changes back to upstream

The inverse of `update-claude`. Submits changes from the local `.claude/` folder to the upstream repository as a pull request.

Workflow:
1. Reads repo and branch from `skills/update-claude/config.md` (shared config)
2. Clones the upstream branch into a temp directory
3. Compares local `.claude/` against the clone's `src/claude/` to classify files as **upstream** (exist in both) or **local-only** (exist only locally)
4. Upstream files are updated automatically
5. Local-only files are shown to the user via `AskUserQuestion multiSelect` — only approved files are included
6. Creates a `submit/YYYY-MM-DD` branch, commits, pushes, and opens a PR targeting the configured branch
7. Detects no-op (nothing actually changed) and exits cleanly without creating a PR
8. Cleans up the temp clone on completion or failure